### PR TITLE
Updated Readyz to return 500 in case one service is down

### DIFF
--- a/pkg/apiserver/web/readyz.go
+++ b/pkg/apiserver/web/readyz.go
@@ -59,5 +59,10 @@ func (s *StatusSessions) Readyz(c echo.Context) error {
 		Sqs:      s.checkSqsStatus(),
 	}
 
+	// If one of them is false
+	if !readyResponse.Database || !readyResponse.Sqs {
+		return c.JSON(http.StatusInternalServerError, readyResponse)
+	}
+
 	return c.JSON(http.StatusOK, readyResponse)
 }


### PR DESCRIPTION
## Description

Updated the 'readyz' endpoint to return 500 in case one service is returning errors.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
