### PR TITLE
Add the option to read the token from disk to the performance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,13 +152,19 @@ test-e2e:
 	@. local/.env.local && go test -race github.com/adobe/cluster-registry/test/e2e -count=1 -v
 	$(shell pwd)/local/cleanup.sh
 
-## Make sure you have set the APISERVER_AUTH_TOKEN env variable
-## Use PERFORMANCE_TEST_TIME env var to set the benchmark time per endpoint
-## Use APISERVER_ENDPOINT env var to set the endpoint for the benchmark
+## Make sure you have set the APISERVER_AUTH_TOKEN env variable.
+## Use PERFORMANCE_TEST_TIME env var to set the benchmark time per endpoint.
+## Use APISERVER_ENDPOINT env var to set the endpoint for the benchmark.
+## The env variables from the local env will overwrite th local/.env.local ones.
 .PHONY: test-performance
 test-performance: ## Outputs requests/s, average req time, 99.9th percentile req time
 	@. local/.env.local \
-		&& export APISERVER_ENDPOINT=${APISERVER_ENDPOINT} \
+		&& export LOCAL_ENV_APISERVER_ENDPOINT=${APISERVER_ENDPOINT} \
+		&& export LOCAL_ENV_APISERVER_AUTH_TOKEN=${APISERVER_AUTH_TOKEN} \
+		&& export LOCAL_ENV_PERFORMANCE_TEST_TIME=${PERFORMANCE_TEST_TIME} \
+		&& export LOCAL_ENV_IMAGE_PERFORMANCE_TESTS=${IMAGE_PERFORMANCE_TESTS} \
+		&& export LOCAL_ENV_TAG=${TAG} \
+		&& export LOCAL_ENV_NETWORK=${NETWORK} \
 		&& test/performance/scripts/run_bech_container.sh
 
 

--- a/docs/developer-guides/testing.md
+++ b/docs/developer-guides/testing.md
@@ -10,15 +10,25 @@ To run integration tests execute `make test-e2e`.
 
 To run performance test locally you should run:
 
-`. local/.env.local` To set the IMAGE_PERFORMANCE_TESTS its TAG and the container NETWORK.
-`make test-performance $APISERVER_ENDPOINT=http://api-url/ PERFORMANCE_TEST_TIME=10 APISERVER_AUTH_TOKEN=$token`.
+`make test-performance APISERVER_AUTH_TOKEN=$token APISERVER_ENDPOINT=http://api-url/ PERFORMANCE_TEST_TIME=10`.
 
-The `APISERVER_ENDPOINT` and `PERFORMANCE_TEST_TIME` have the defaults http://localhost:8080 and 10s, but the `APISERVER_AUTH_TOKEN` is mandatory.
+It will take the defaults from the `local/.env.local` file but it will overwrite them form the local env if the environment variables exists.
+If the file and the env vars are missing the `APISERVER_ENDPOINT` and `PERFORMANCE_TEST_TIME` have the defaults `http://localhost:8080` and `10` seconds, but the `APISERVER_AUTH_TOKEN` is mandatory.
 
 To generate a local token you can use the following code:
 ```
+	import (
+	"github.com/adobe/cluster-registry/pkg/config"
+	"github.com/adobe/cluster-registry/test/jwt"
+
+	"fmt"
+)
+
+func main() {
+
 	appConfig, _ := config.LoadApiConfig()
 	jwtToken := jwt.GenerateSignedToken(appConfig, false, "test/testdata/dummyRsaPrivateKey.pem", "", jwt.Claim{})
 
 	fmt.Println(jwtToken)
+}
 ```

--- a/test/performance/scripts/benchmark.sh
+++ b/test/performance/scripts/benchmark.sh
@@ -68,7 +68,7 @@ run_benckmarks "${ENDPOINT}/livez" "${NR_OF_SECS}"
 
 if [ -z "${APISERVER_AUTH_TOKEN}" ]; then
     if [ -z "${TOKEN_PATH}" ]; then
-        printf "ERROR: Missing env variable API_AUTH_TOKEN for the rest of the endpoints.\n" 1>&2
+        printf "ERROR: Missing env variable APISERVER_AUTH_TOKEN for the rest of the endpoints.\n" 1>&2
         exit 1
     fi
     APISERVER_AUTH_TOKEN=$(cat "${TOKEN_PATH}")

--- a/test/performance/scripts/run_bech_container.sh
+++ b/test/performance/scripts/run_bech_container.sh
@@ -1,18 +1,44 @@
 #!/usr/bin/env bash
 
 # This script is so we can pass the enviorment variables from the /local/.env.local
-# file to the container that runs the benchmark.sh script when ran from the Makefile
+# file to the container that runs the benchmark.sh script when ran from the Makefile.
+#
+# The env variables with the prefix LOCAL_ENV are from the env of the user that ran
+# the make target, and the ones without the prefix are from the /local/.env.local file.
+#
+# Only the container run env variables have defaults in this script the APISERVER_ENDPOINT
+# and PERFORMANCE_TEST_TIME have defaults inside the container. The APISERVER_AUTH_TOKEN
+# is required.
 
-if [ -z "${TAG}" ]; then
-    TAG="v$(cat "$(git rev-parse --show-toplevel)/VERSION")-$(git rev-parse --short HEAD)"
+# If LOCAL_ENV_ exists and is not empty
+if [[ -n "${LOCAL_ENV_APISERVER_ENDPOINT}" ]]; then
+    APISERVER_ENDPOINT="${LOCAL_ENV_APISERVER_ENDPOINT}"
 fi
 
-if [ -z "${IMAGE_PERFORMANCE_TESTS}" ]; then
+if [[ -n "${LOCAL_ENV_APISERVER_AUTH_TOKEN}" ]]; then
+    APISERVER_AUTH_TOKEN="${LOCAL_ENV_APISERVER_AUTH_TOKEN}"
+fi
+
+if [[ -n "${LOCAL_ENV_PERFORMANCE_TEST_TIME}" ]]; then
+    PERFORMANCE_TEST_TIME="${LOCAL_ENV_PERFORMANCE_TEST_TIME}"
+fi
+
+if [[ -n "${LOCAL_ENV_NETWORK}" ]]; then
+    NETWORK="${LOCAL_ENV_NETWORK}"
+elif [ -z "${NETWORK}" ]; then
+    NETWORK="cluster-registry-net"
+fi
+
+if [[ -n "${LOCAL_ENV_IMAGE_PERFORMANCE_TESTS}" ]]; then
+    IMAGE_PERFORMANCE_TESTS="${LOCAL_ENV_IMAGE_PERFORMANCE_TESTS}"
+elif [ -z "${IMAGE_PERFORMANCE_TESTS}" ]; then
     IMAGE_PERFORMANCE_TESTS="ghcr.io/adobe/performance-tests"
 fi
 
-if [ -z "${NETWORK}" ]; then
-    NETWORK="cluster-registry-net"
+if [[ -n "${LOCAL_ENV_TAG}" ]]; then
+    TAG="${LOCAL_ENV_TAG}"
+elif [ -z "${TAG}" ]; then
+    TAG="v$(cat "$(git rev-parse --show-toplevel)/VERSION")-$(git rev-parse --short HEAD)"
 fi
 
 docker run --rm --network="${NETWORK}" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the option to read the token from disk to the performance tests
Add some fixes to the make target and scripts of the performance tests

## Motivation and Context

This is needed to read the token from an init container volume when deployed to Kubernetes.

## How Has This Been Tested?

Local tested.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
