### PR TITLE
Update the metrics buckets for request duration tests

### DIFF
--- a/test/slt/metrics/metrics.go
+++ b/test/slt/metrics/metrics.go
@@ -21,7 +21,7 @@ var logger echo.Logger
 
 const metricsPrefix = "cluster_registry_slt"
 
-var reqDurBuckets = []float64{.25, .5, 1, 3, 5, 10, 15, 20}
+var reqDurBuckets = []float64{.01, .05, .1, .2, .3, .5, .75, 1, 3, 5, 10, 15, 20, 40, 60}
 
 var TestStatus = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{


### PR DESCRIPTION
The buckets weren’t granular enough to give a good approximation for the avg req time in the get cluster test.