### PR TITLE
Add "last" element handling in nested arrays

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.5.0-unstable
+1.5.1-unstable

--- a/pkg/client/controllers/servicemetadatawatcher_controller.go
+++ b/pkg/client/controllers/servicemetadatawatcher_controller.go
@@ -321,7 +321,7 @@ func createServiceMetadataPatch(serviceId string, namespace string, field string
 // path is a list of keys separated by dots, e.g. "spec.template.spec.containers[0].image"
 // if the field is a slice, the last key must be in the form of "key[index]"
 func getNestedString(object interface{}, path []string) (string, bool, error) {
-	re := regexp.MustCompile(`^(.*)\[(\d+)]$`)
+	re := regexp.MustCompile(`^(.*)\[(\d+|[a-z]+)]$`)
 	var cpath []string
 	for i, key := range path {
 		m := re.FindStringSubmatch(key)

--- a/pkg/client/controllers/servicemetadatawatcher_controller.go
+++ b/pkg/client/controllers/servicemetadatawatcher_controller.go
@@ -15,6 +15,12 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
 	registryv1 "github.com/adobe/cluster-registry/pkg/api/registry/v1"
 	registryv1alpha1 "github.com/adobe/cluster-registry/pkg/api/registry/v1alpha1"
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -25,17 +31,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
-	"reflect"
-	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	crevent "sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strconv"
-	"strings"
-	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -326,10 +327,16 @@ func getNestedString(object interface{}, path []string) (string, bool, error) {
 		m := re.FindStringSubmatch(key)
 		if len(m) > 0 {
 			cpath = append(cpath, m[1])
-			index, _ := strconv.Atoi(m[2])
 			slice, found, err := unstructured.NestedSlice(object.(map[string]interface{}), cpath...)
 			if !found || err != nil {
 				return "", false, err
+			}
+			index, err := strconv.Atoi(m[2])
+			if err != nil && m[2] != "last" {
+				return "", false, fmt.Errorf("invalid array index: %s", m[2])
+			}
+			if m[2] == "last" {
+				index = len(slice) - 1
 			}
 			if len(slice) <= index {
 				return "", false, fmt.Errorf("index out of range")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Our cluster-registry integration, for the Edge GW to CGW migration tools, needs monitoring for various client CRs, during the migration process, especially their CR status, but also other parameters as well.
Sometimes the status is an array of statuses, so we would need to monitor only the last status entry, since that's the valid one for us.
We don't have the length for those arrays apriori, so we cannot call the ServiceMetadataWatcher with:
- objectReference:
      apiVersion: pdm.adobe.io/v1
      kind: RequestProcessing
      name: maia-e2e-test-rp-mircea
    watchedFields:
    - dst: policy_id
      src: spec.authPolicies[X].policyId
where X is a number, the last in the array, so we would need a "last" string in the watchedFields, to represent the last monitored entry in the array, no matter its length.
This PR adds the "last" string in the CR handling.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
