### PR TITLE
Add missing RBAC for ServiceMetadataWatchers

### DIFF
--- a/charts/cluster-registry-client/Chart.yaml
+++ b/charts/cluster-registry-client/Chart.yaml
@@ -15,5 +15,5 @@ maintainers:
   - name: radu-catalina
     email: caradu@adobe.com
 
-version: 0.1.8
-appVersion: v1.4.2
+version: 0.2.0
+appVersion: v1.5.1

--- a/charts/cluster-registry-client/templates/clusterrole.yaml
+++ b/charts/cluster-registry-client/templates/clusterrole.yaml
@@ -31,3 +31,29 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - registry.ethos.adobe.com
+    resources:
+      - servicemetadatawatchers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - registry.ethos.adobe.com
+    resources:
+      - servicemetadatawatchers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - registry.ethos.adobe.com
+    resources:
+      - servicemetadatawatchers/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/charts/cluster-registry-client/templates/clusterrole.yaml
+++ b/charts/cluster-registry-client/templates/clusterrole.yaml
@@ -57,3 +57,14 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - watch
+      - list
+  {{- with .Values.extraRBAC }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/cluster-registry-client/templates/configmap.yaml
+++ b/charts/cluster-registry-client/templates/configmap.yaml
@@ -35,4 +35,16 @@ data:
       {{- else }}
       alertMap: []
       {{- end }}
+    {{- if .Values.clusterRegistryClient.serviceMetadata }}
+    serviceMetadata:
+      serviceIdAnnotation: {{ .Values.clusterRegistryClient.serviceIdAnnotation | default "adobe.serviceid" }}
+      {{- if .Values.clusterRegistryClient.serviceMetadata.watchedGVKs }}
+      watchedGVKs:
+      {{- range $_, $gvk := .Values.clusterRegistryClient.serviceMetadata.watchedGVKs }}
+        - group: {{ $gvk.group }}
+          version: {{ $gvk.version }}
+          kind: {{ $gvk.kind }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
At a bare minimum the new version of cluster-registry-client (1.5.0+) requires some additional permissions for interacting with the new ServiceMetadataWatcher objects at a cluster level.