### PR TITLE
Feature/service metadata fixes 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ docker/
 
 # build artifacts
 /cluster-registry*
-kubeconfig
+kubeconfig*
 .dynamodb
 .hack*
 


### PR DESCRIPTION
Add a check for available GVKs using a discovery client. If a configured GVK isn't installed on the cluster it will skip it instead of returning an error.

Improve field parsing for `servicemetadatawatcher.spec.watchedServiceObjects.watchedFields.src`:
- remove "last" as a possible index value, replaced with support for negative indexes (e.g., `-1` is the last, `-2` second to last etc.)
- add support for maps (e.g., `metadata.annotations[some.key/example]`)
- refactored parsing logic to (hopefully) make it easier to understand