### PR TITLE
fix: remove default leaderElection.namespace from values

### DIFF
--- a/charts/cluster-registry-sync-manager/Chart.yaml
+++ b/charts/cluster-registry-sync-manager/Chart.yaml
@@ -15,5 +15,5 @@ maintainers:
   - name: radu-catalina
     email: caradu@adobe.com
 
-version: 0.1.0
+version: 0.1.1
 appVersion: v1.6.0

--- a/charts/cluster-registry-sync-manager/README.md
+++ b/charts/cluster-registry-sync-manager/README.md
@@ -1,6 +1,6 @@
 # cluster-registry-sync-manager
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
 
 Cluster Registry is a Rest API representing the source of record for all Kubernetes clusters in the infrastructure fleet. All clusters are automatically registered, and the information is accurately reflected in the Cluster Registry using a client-server architecture.
 
@@ -21,9 +21,7 @@ Cluster Registry is a Rest API representing the source of record for all Kuberne
 | clusterRegistrySyncManager.leaderElection.leaderElect | bool | `false` |  |
 | clusterRegistrySyncManager.leaderElection.resourceLock | string | `"leases"` |  |
 | clusterRegistrySyncManager.leaderElection.resourceName | string | `"sync.registry.ethos.adobe.com"` |  |
-| clusterRegistrySyncManager.leaderElection.resourceNamespace | string | `"cluster-registry"` |  |
 | clusterRegistrySyncManager.metrics.bindAddress | string | `"0.0.0.0:9090"` |  |
-| clusterRegistrySyncManager.namespace | string | `"cluster-registry"` |  |
 | clusterRegistrySyncManager.watchedGVKs | object | `{}` |  |
 | clusterRegistrySyncManager.webhook.port | int | `9443` |  |
 | fullnameOverride | string | `"cluster-registry-sync-manager"` |  |

--- a/charts/cluster-registry-sync-manager/values.yaml
+++ b/charts/cluster-registry-sync-manager/values.yaml
@@ -43,7 +43,6 @@ clusterRegistrySyncManager:
     port: 9443
   leaderElection:
     leaderElect: false
-    resourceNamespace: cluster-registry
     resourceName: sync.registry.ethos.adobe.com
     resourceLock: leases
   watchedGVKs: {}


### PR DESCRIPTION
Both namespace references in the values file are redundant, since we're using `.Release.Namespace` in the configmap template anyway.