### PR TITLE
fix: standardize resource naming in chart templates

### DIFF
--- a/charts/cluster-registry-client/Chart.yaml
+++ b/charts/cluster-registry-client/Chart.yaml
@@ -15,5 +15,5 @@ maintainers:
   - name: radu-catalina
     email: caradu@adobe.com
 
-version: 0.3.0
+version: 0.3.1
 appVersion: v1.6.0

--- a/charts/cluster-registry-client/README.md
+++ b/charts/cluster-registry-client/README.md
@@ -1,6 +1,6 @@
 # cluster-registry-client
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
 
 Cluster Registry is a Rest API representing the source of record for all Kubernetes clusters in the infrastructure fleet. All clusters are automatically registered, and the information is accurately reflected in the Cluster Registry using a client-server architecture.
 

--- a/charts/cluster-registry-client/templates/clusterrole.yaml
+++ b/charts/cluster-registry-client/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cluster-registry-client
+  name: {{ include "cluster-registry-client.fullname" . }}
   labels:
     {{- include "cluster-registry-client.labels" . | nindent 4 }}
 rules:

--- a/charts/cluster-registry-client/templates/clusterrolebinding.yaml
+++ b/charts/cluster-registry-client/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cluster-registry-client
+  name: {{ include "cluster-registry-client.fullname" . }}
   labels:
     {{- include "cluster-registry-client.labels" . | nindent 4 }}
 roleRef:

--- a/charts/cluster-registry-client/templates/configmap.yaml
+++ b/charts/cluster-registry-client/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: client-config
+  name: {{ include "cluster-registry-client.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-registry-client.labels" . | nindent 4 }}

--- a/charts/cluster-registry-client/templates/deployment.yaml
+++ b/charts/cluster-registry-client/templates/deployment.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:   {{- include "cluster-registry-client.labels" . | nindent 4 }}
+  labels:
+    {{- include "cluster-registry-client.labels" . | nindent 4 }}
   name: {{ include "cluster-registry-client.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -29,7 +30,7 @@ spec:
           image: "{{ .Values.image.registry }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
-            - name: client-config
+            - name: {{ include "cluster-registry-client.fullname" . }}-config
               mountPath: /config.yaml
               subPath: config.yaml
           ports:
@@ -81,8 +82,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
       volumes:
-        - name: client-config
+        - name: {{ include "cluster-registry-client.fullname" . }}-config
           configMap:
-            name: client-config
+            name: {{ include "cluster-registry-client.fullname" . }}-config
       serviceAccountName: {{ include "cluster-registry-client.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | required ".Values.terminationGracePeriodSeconds is required"  }}

--- a/charts/cluster-registry-client/templates/poddisruptionbudget.yaml
+++ b/charts/cluster-registry-client/templates/poddisruptionbudget.yaml
@@ -8,7 +8,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     {{- include "cluster-registry-client.labels" . | nindent 4 }}
-  name: {{ template "cluster-registry-client.fullname" . }}
+  name: {{ include "cluster-registry-client.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:

--- a/charts/cluster-registry-client/templates/podmonitor.yaml
+++ b/charts/cluster-registry-client/templates/podmonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.podMonitor.extraLabels }}
     {{- toYaml .Values.podMonitor.extraLabels | nindent 4 }}
     {{- end }}
-  name: cluster-registry-client
+  name: {{ include "cluster-registry-client.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   jobLabel: app

--- a/charts/cluster-registry-client/templates/role-leader-election.yaml
+++ b/charts/cluster-registry-client/templates/role-leader-election.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: cluster-registry-leader-election
+  name: {{ include "cluster-registry-client.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-registry-client.labels" . | nindent 4 }}

--- a/charts/cluster-registry-client/templates/rolebinding-leader-election.yaml
+++ b/charts/cluster-registry-client/templates/rolebinding-leader-election.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cluster-registry-leader-election
+  name: {{ include "cluster-registry-client.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-registry-client.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cluster-registry-leader-election
+  name: {{ include "cluster-registry-client.fullname" . }}-leader-election
 subjects:
   - kind: ServiceAccount
     name: {{ include "cluster-registry-client.serviceAccountName" . }}

--- a/charts/cluster-registry-sync-manager/Chart.yaml
+++ b/charts/cluster-registry-sync-manager/Chart.yaml
@@ -15,5 +15,5 @@ maintainers:
   - name: radu-catalina
     email: caradu@adobe.com
 
-version: 0.1.2
+version: 0.1.3
 appVersion: v1.6.0

--- a/charts/cluster-registry-sync-manager/README.md
+++ b/charts/cluster-registry-sync-manager/README.md
@@ -1,6 +1,6 @@
 # cluster-registry-sync-manager
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.0](https://img.shields.io/badge/AppVersion-v1.6.0-informational?style=flat-square)
 
 Cluster Registry is a Rest API representing the source of record for all Kubernetes clusters in the infrastructure fleet. All clusters are automatically registered, and the information is accurately reflected in the Cluster Registry using a client-server architecture.
 

--- a/charts/cluster-registry-sync-manager/templates/clusterrole.yaml
+++ b/charts/cluster-registry-sync-manager/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cluster-registry-sync-manager
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}
   labels:
     {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}
 rules:

--- a/charts/cluster-registry-sync-manager/templates/clusterrolebinding.yaml
+++ b/charts/cluster-registry-sync-manager/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cluster-registry-sync-manager
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}
   labels:
     {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}
 roleRef:

--- a/charts/cluster-registry-sync-manager/templates/configmap.yaml
+++ b/charts/cluster-registry-sync-manager/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sync-manager-config
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}

--- a/charts/cluster-registry-sync-manager/templates/deployment.yaml
+++ b/charts/cluster-registry-sync-manager/templates/deployment.yaml
@@ -1,7 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:   {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}
+  labels:
+    {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}
   name: {{ include "cluster-registry-sync-manager.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -29,7 +30,7 @@ spec:
           image: "{{ .Values.image.registry }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
-            - name: sync-manager-config
+            - name: {{ include "cluster-registry-sync-manager.fullname" . }}-config
               mountPath: /config.yaml
               subPath: config.yaml
           ports:
@@ -81,8 +82,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
       volumes:
-        - name: sync-manager-config
+        - name: {{ include "cluster-registry-sync-manager.fullname" . }}-config
           configMap:
-            name: sync-manager-config
+            name: {{ include "cluster-registry-sync-manager.fullname" . }}-config
       serviceAccountName: {{ include "cluster-registry-sync-manager.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | required ".Values.terminationGracePeriodSeconds is required"  }}

--- a/charts/cluster-registry-sync-manager/templates/poddisruptionbudget.yaml
+++ b/charts/cluster-registry-sync-manager/templates/poddisruptionbudget.yaml
@@ -8,7 +8,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}
-  name: {{ template "cluster-registry-sync-manager.fullname" . }}
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:

--- a/charts/cluster-registry-sync-manager/templates/podmonitor.yaml
+++ b/charts/cluster-registry-sync-manager/templates/podmonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.podMonitor.extraLabels }}
     {{- toYaml .Values.podMonitor.extraLabels | nindent 4 }}
     {{- end }}
-  name: cluster-registry-sync-manager
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   jobLabel: app

--- a/charts/cluster-registry-sync-manager/templates/role-leader-election.yaml
+++ b/charts/cluster-registry-sync-manager/templates/role-leader-election.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: cluster-registry-leader-election
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}

--- a/charts/cluster-registry-sync-manager/templates/rolebinding-leader-election.yaml
+++ b/charts/cluster-registry-sync-manager/templates/rolebinding-leader-election.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cluster-registry-leader-election
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster-registry-sync-manager.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cluster-registry-leader-election
+  name: {{ include "cluster-registry-sync-manager.fullname" . }}-leader-election
 subjects:
   - kind: ServiceAccount
     name: {{ include "cluster-registry-sync-manager.serviceAccountName" . }}


### PR DESCRIPTION
issue: both charts had the same role/binding name for leader-election